### PR TITLE
TestBrandedToken Implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install nodejs
   - sudo apt-get install npm
-  - sudo apt-get install software-properties-common
-  - sudo add-apt-repository -y ppa:ethereum/ethereum
-  - sudo apt-get update
-  - sudo apt-get --allow-unauthenticated install solc
 install:
   - npm install
 before_script:

--- a/contracts/test/branded_token/TestBrandedToken.sol
+++ b/contracts/test/branded_token/TestBrandedToken.sol
@@ -44,14 +44,14 @@ contract TestBrandedToken {
     /**
      * @notice Contract constructor.
      *
-     * @dev Ordering of constructor parameters:
-     *      valueToken
-     *      symbol
-     *      name
-     *      decimals
-     *      conversionRate
-     *      conversionRateDecimals
-     *      organization contract address
+     * @dev It takes below parameters in order:
+     *      - valueToken
+     *      - symbol
+     *      - name
+     *      - decimals
+     *      - conversionRate
+     *      - conversionRateDecimals
+     *      - organization contract address
      */
     constructor(
         address,
@@ -72,8 +72,8 @@ contract TestBrandedToken {
      * @notice Mocks BT requestStake method.
      *
      * @dev It takes below parameters in order:
-     *      amount to stake
-     *      amount to mint
+     *      - amount to stake
+     *      - amount to mint
      *
      * @return Unique hash for each stake request.
      */
@@ -93,10 +93,10 @@ contract TestBrandedToken {
      * @notice Mocks BT acceptStakeRequest method.
      *
      * @dev It takes below parameters in order:
-     *      stake request hash
-     *      r is the actual signature
-     *      s is the second point on the curve in order to ecrecover
-     *      v selects the final public key
+     *      - stake request hash
+     *      - r is the actual signature
+     *      - s is the second point on the curve in order to ecrecover
+     *      - v selects the final public key
      *
      * @return True if execution is successful.
      */

--- a/contracts/test/branded_token/TestBrandedToken.sol
+++ b/contracts/test/branded_token/TestBrandedToken.sol
@@ -72,8 +72,8 @@ contract TestBrandedToken {
      * @notice Mocks BT requestStake method.
      *
      * @dev It takes below parameters in order:
-     *      amount to stake.
-     *      amount to mint.
+     *      amount to stake
+     *      amount to mint
      *
      * @return Unique hash for each stake request.
      */
@@ -93,10 +93,10 @@ contract TestBrandedToken {
      * @notice Mocks BT acceptStakeRequest method.
      *
      * @dev It takes below parameters in order:
-     *      stake request hash.
-     *      r is the actual signature.
-     *      s is the second point on the curve in order to ecrecover.
-     *      v selects the final public key.
+     *      stake request hash
+     *      r is the actual signature
+     *      s is the second point on the curve in order to ecrecover
+     *      v selects the final public key
      *
      * @return True if execution is successful.
      */

--- a/contracts/test/branded_token/TestBrandedToken.sol
+++ b/contracts/test/branded_token/TestBrandedToken.sol
@@ -17,7 +17,7 @@ pragma solidity ^0.4.24;
 /**
  * @title TestBrandedToken.
  *
- * @notice It's needed for testing branded token contract.
+ * @notice Supports testing of BrandedToken (BT).
  */
 contract TestBrandedToken {
 
@@ -51,7 +51,7 @@ contract TestBrandedToken {
      *      decimals
      *      conversionRate
      *      conversionRateDecimals
-     *      Organization contract address
+     *      organization contract address
      */
     constructor(
         address,
@@ -72,10 +72,10 @@ contract TestBrandedToken {
      * @notice Mocks BT requestStake method.
      *
      * @dev It takes below parameters in order:
-     *      - Amount to Stake.
-     *      - Amount to Mint.
+     *      amount to stake.
+     *      amount to mint.
      *
-     * @return unique hash for each stake request.
+     * @return Unique hash for each stake request.
      */
     function requestStake(
         uint256,
@@ -93,12 +93,12 @@ contract TestBrandedToken {
      * @notice Mocks BT acceptStakeRequest method.
      *
      * @dev It takes below parameters in order:
-     *      - Unique request hash.
-     *      - r is the actual signature.
-     *      - s is the second point on the curve in order to ecrecover.
-     *      - v selects the final public key.
+     *      stake request hash.
+     *      r is the actual signature.
+     *      s is the second point on the curve in order to ecrecover.
+     *      v selects the final public key.
      *
-     * @return Returns true if execution is successful.
+     * @return True if execution is successful.
      */
     function acceptStakeRequest(
         bytes32,

--- a/contracts/test/branded_token/TestBrandedToken.sol
+++ b/contracts/test/branded_token/TestBrandedToken.sol
@@ -1,0 +1,119 @@
+pragma solidity ^0.4.24;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @title TestBrandedToken.
+ *
+ * @notice It's needed for testing branded token contract.
+ */
+contract TestBrandedToken {
+
+    /* Events */
+
+    event StakeRequested(
+        bytes32 indexed _stakeRequestHash,
+        address _staker,
+        uint256 _stake,
+        uint256 _nonce
+    );
+
+    event StakeRequestAccepted(address _staker, uint256 _stake);
+
+    event Transfer(
+        address indexed _from,
+        address indexed _to,
+        uint256 _value
+    );
+
+
+    /* Special Functions */
+
+    /**
+     * @notice Contract constructor.
+     *
+     * @dev Ordering of constructor parameters:
+     *      valueToken
+     *      symbol
+     *      name
+     *      decimals
+     *      conversionRate
+     *      conversionRateDecimals
+     *      Organization contract address
+     */
+    constructor(
+        address,
+        string,
+        string,
+        uint8,
+        uint256,
+        uint8,
+        address
+    )
+        public
+    {}
+
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks BT requestStake method.
+     *
+     * @dev It takes below parameters in order:
+     *      - Amount to Stake.
+     *      - Amount to Mint.
+     *
+     * @return unique hash for each stake request.
+     */
+    function requestStake(
+        uint256,
+        uint256
+    )
+        external
+        returns (bytes32)
+    {
+        emit StakeRequested(bytes32(0), address(0), uint256(0), uint256(0));
+
+        return bytes32(0);
+    }
+
+    /**
+     * @notice Mocks BT acceptStakeRequest method.
+     *
+     * @dev It takes below parameters in order:
+     *      - Unique request hash.
+     *      - r is the actual signature.
+     *      - s is the second point on the curve in order to ecrecover.
+     *      - v selects the final public key.
+     *
+     * @return Returns true if execution is successful.
+     */
+    function acceptStakeRequest(
+        bytes32,
+        bytes32,
+        bytes32,
+        uint8
+    )
+        external
+        returns (bool)
+    {
+        emit StakeRequestAccepted(address(0), uint256(0));
+
+        emit Transfer(address(0), address(0), uint256(0));
+
+        return true;
+    }
+
+}

--- a/test/branded_token/accept_stake_request.js
+++ b/test/branded_token/accept_stake_request.js
@@ -1,0 +1,65 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const BN = require('bn.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder.js');
+
+const web3 = require('../test_lib/web3.js');
+const utils = require('../test_lib/utils');
+const brandedTokenUtils = require('./utils');
+
+contract('TestBrandedToken::requestStake', async () => {
+    contract('Event', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Checks that StakeRequestAccepted & Transfer events are emitted successfully.', async () => {
+            const {
+                testBrandedToken,
+            } = await brandedTokenUtils.setupTestBrandedToken(accountProvider);
+
+            const stakeRequestHash = web3.utils.soliditySha3('test');
+            const r = web3.utils.soliditySha3('r');
+            const s = web3.utils.soliditySha3('r');
+            const v = 0;
+            const transactionResponse = await testBrandedToken.acceptStakeRequest(
+                stakeRequestHash,
+                r,
+                s,
+                v,
+            );
+
+            const events = Event.decodeTransactionResponse(transactionResponse);
+
+            assert.strictEqual(events.length, 2);
+
+            Event.assertEqual(events[0], {
+                name: 'StakeRequestAccepted',
+                args: {
+                    _staker: utils.NULL_ADDRESS,
+                    _stake: new BN(0),
+                },
+            });
+
+            Event.assertEqual(events[1], {
+                name: 'Transfer',
+                args: {
+                    _from: utils.NULL_ADDRESS,
+                    _to: utils.NULL_ADDRESS,
+                    _value: new BN(0),
+                },
+            });
+        });
+    });
+});

--- a/test/branded_token/accept_stake_request.js
+++ b/test/branded_token/accept_stake_request.js
@@ -20,20 +20,20 @@ const web3 = require('../test_lib/web3.js');
 const utils = require('../test_lib/utils');
 const brandedTokenUtils = require('./utils');
 
-contract('TestBrandedToken::requestStake', async () => {
+contract('BrandedToken::acceptStakeRequest', async () => {
     contract('Event', async (accounts) => {
         const accountProvider = new AccountProvider(accounts);
 
-        it('Checks that StakeRequestAccepted & Transfer events are emitted successfully.', async () => {
+        it('Emits StakeRequestAccepted and Transfer events.', async () => {
             const {
-                testBrandedToken,
-            } = await brandedTokenUtils.setupTestBrandedToken(accountProvider);
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(accountProvider);
 
             const stakeRequestHash = web3.utils.soliditySha3('test');
             const r = web3.utils.soliditySha3('r');
             const s = web3.utils.soliditySha3('r');
             const v = 0;
-            const transactionResponse = await testBrandedToken.acceptStakeRequest(
+            const transactionResponse = await brandedToken.acceptStakeRequest(
                 stakeRequestHash,
                 r,
                 s,

--- a/test/branded_token/request_stake.js
+++ b/test/branded_token/request_stake.js
@@ -1,0 +1,53 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const BN = require('bn.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder.js');
+
+const utils = require('../test_lib/utils');
+const brandedTokenUtils = require('./utils');
+
+contract('TestBrandedToken::requestStake', async () => {
+    contract('Event', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Checks that StakeRequested event is emitted successfully.', async () => {
+            const {
+                testBrandedToken,
+            } = await brandedTokenUtils.setupTestBrandedToken(accountProvider);
+
+            const stakeAmount = 1;
+            const mintAmount = 5;
+            const transactionResponse = await testBrandedToken.requestStake(
+                stakeAmount,
+                mintAmount,
+            );
+
+            const events = Event.decodeTransactionResponse(transactionResponse);
+
+            assert.strictEqual(events.length, 1);
+
+            Event.assertEqual(events[0], {
+                name: 'StakeRequested',
+                args: {
+                    _stakeRequestHash: utils.NULL_BYTES32,
+                    _staker: utils.NULL_ADDRESS,
+                    _stake: new BN(0),
+                    _nonce: new BN(0),
+                },
+            });
+        });
+    });
+});

--- a/test/branded_token/request_stake.js
+++ b/test/branded_token/request_stake.js
@@ -19,18 +19,18 @@ const { Event } = require('../test_lib/event_decoder.js');
 const utils = require('../test_lib/utils');
 const brandedTokenUtils = require('./utils');
 
-contract('TestBrandedToken::requestStake', async () => {
+contract('BrandedToken::requestStake', async () => {
     contract('Event', async (accounts) => {
         const accountProvider = new AccountProvider(accounts);
 
-        it('Checks that StakeRequested event is emitted successfully.', async () => {
+        it('Emits StakeRequested event.', async () => {
             const {
-                testBrandedToken,
-            } = await brandedTokenUtils.setupTestBrandedToken(accountProvider);
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(accountProvider);
 
             const stakeAmount = 1;
-            const mintAmount = 5;
-            const transactionResponse = await testBrandedToken.requestStake(
+            const mintAmount = 1;
+            const transactionResponse = await brandedToken.requestStake(
                 stakeAmount,
                 mintAmount,
             );

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const TestBrandedToken = artifacts.require('TestBrandedToken');
+const BrandedToken = artifacts.require('TestBrandedToken');
 
 /**
- * Setup TestBrandedToken.
+ * Setup BrandedToken.
  */
-module.exports.setupTestBrandedToken = async (accountProvider) => {
+module.exports.setupBrandedToken = async (accountProvider) => {
     const eip20Token = accountProvider.get();
     const symbol = 'Test';
     const name = 'Test';
@@ -26,7 +26,7 @@ module.exports.setupTestBrandedToken = async (accountProvider) => {
     const conversionRateDecimals = 0;
     const organization = accountProvider.get();
 
-    const testBrandedToken = await TestBrandedToken.new(
+    const brandedToken = await BrandedToken.new(
         eip20Token,
         symbol,
         name,
@@ -37,6 +37,6 @@ module.exports.setupTestBrandedToken = async (accountProvider) => {
     );
 
     return {
-        testBrandedToken,
+        brandedToken,
     };
 };

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -1,0 +1,42 @@
+// Copyright 2018 OST.com Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const TestBrandedToken = artifacts.require('TestBrandedToken');
+
+/**
+ * Setup TestBrandedToken.
+ */
+module.exports.setupTestBrandedToken = async (accountProvider) => {
+    const eip20Token = accountProvider.get();
+    const symbol = 'Test';
+    const name = 'Test';
+    const decimals = 18;
+    const conversionRate = 10;
+    const conversionRateDecimals = 0;
+    const organization = accountProvider.get();
+
+    const testBrandedToken = await TestBrandedToken.new(
+        eip20Token,
+        symbol,
+        name,
+        decimals,
+        conversionRate,
+        conversionRateDecimals,
+        organization,
+    );
+
+    return {
+        testBrandedToken,
+    };
+};

--- a/test/test_lib/utils.js
+++ b/test/test_lib/utils.js
@@ -15,10 +15,11 @@
 const assert = require('assert');
 const web3 = require('web3');
 
-
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+const NULL_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
 module.exports.NULL_ADDRESS = NULL_ADDRESS;
+module.exports.NULL_BYTES32 = NULL_BYTES32;
 
 module.exports.isNullAddress = address => address === NULL_ADDRESS;
 


### PR DESCRIPTION
The PR Implements TestBrandedToken and mocks below tasks based on OIP-0001: https://github.com/OpenSTFoundation/OIPs/blob/d639dd49ee897880cdead0900c54c9f5fab1cab7/OIPS/oip-0001.md

- Constructor
- RequestStake
- acceptStakeRequest
- Test cases for requestStake and acceptStakeRequest

It's named TestBrandedToken as it can be used later for testing actual BrandedToken.

We have discussion going on gist: https://gist.github.com/jasonklein/d700de6482e17732d352e14aef7ec7ec

Aim is to unblock JS team from economy setup work. Below are not mocked in the current PR as it currently doesn't block JS team work 😄

- Restriction logic
- revokeStakeRequest
- redeem

It will be great if interfaces of constructor, requestStake, acceptStakeRequest **(no. of arguments and argument ordering)** is solid and freezed.
cc: @jasonklein

Fixes #56 
