### PR TITLE
Contracts: add mock restrictions functions to test BT contract.

### DIFF
--- a/contracts/test/branded_token/TestBrandedToken.sol
+++ b/contracts/test/branded_token/TestBrandedToken.sol
@@ -116,4 +116,32 @@ contract TestBrandedToken {
         return true;
     }
 
+    /**
+     * @notice Mocks BT liftRestriction method.
+     *
+     * @dev It takes an array of addresses.
+     *
+     * @return True if execution is successful.
+     */
+    function liftRestriction(address[])
+        external
+        returns (bool)
+    {
+        return true;
+    }
+
+    /**
+     * @notice Mocks BT isUnrestricted method.
+     *
+     * @dev It takes an address.
+     *
+     * @return True if address is unrestricted.
+     */
+    function isUnrestricted(address)
+        external
+        returns (bool)
+    {
+        return true;
+    }
+
 }


### PR DESCRIPTION
Adds mock `liftRestriction` and `isUnrestricted` methods to `TestBrandedToken`.

Resolves #73.