### PR TITLE
Contracts: add setName and setSymbol to BT.

### DIFF
--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -65,6 +65,8 @@ contract BrandedToken is Organized, EIP20Token {
         uint256 _stake
     );
 
+    event SymbolSet(string _symbol);
+
     event NameSet(string _name);
 
 
@@ -474,6 +476,30 @@ contract BrandedToken is Organized, EIP20Token {
             valueToken.transfer(stakeRequest.staker, stakeRequest.stake),
             "ValueToken.transfer returned false."
         );
+
+        return true;
+    }
+
+    /**
+     * @notice Sets symbol.
+     *
+     * @dev Function requires:
+     *          - msg.sender is a worker
+     *
+     * @param _symbol The value to which symbol is set.
+     *
+     * @return success_ True.
+     */
+    function setSymbol(
+        string calldata _symbol
+    )
+        external
+        onlyWorker
+        returns (bool success_)
+    {
+        tokenSymbol = _symbol;
+
+        emit SymbolSet(tokenSymbol);
 
         return true;
     }

--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -65,6 +65,8 @@ contract BrandedToken is Organized, EIP20Token {
         uint256 _stake
     );
 
+    event NameSet(string _name);
+
 
     /* Structs */
 
@@ -472,6 +474,30 @@ contract BrandedToken is Organized, EIP20Token {
             valueToken.transfer(stakeRequest.staker, stakeRequest.stake),
             "ValueToken.transfer returned false."
         );
+
+        return true;
+    }
+
+    /**
+     * @notice Sets name.
+     *
+     * @dev Function requires:
+     *          - msg.sender is a worker
+     *
+     * @param _name The value to which name is set.
+     *
+     * @return success_ True.
+     */
+    function setName(
+        string calldata _name
+    )
+        external
+        onlyWorker
+        returns (bool success_)
+    {
+        tokenName = _name;
+
+        emit NameSet(tokenName);
 
         return true;
     }

--- a/contracts/EIP20Token.sol
+++ b/contracts/EIP20Token.sol
@@ -48,11 +48,16 @@ contract EIP20Token is EIP20Interface {
      *  @param _name Name of the token.
      *  @param _decimals Decimal places of the token.
      */
-    constructor(string memory _symbol, string memory _name, uint8 _decimals) public
+    constructor(
+        string memory _symbol,
+        string memory _name,
+        uint8 _decimals
+    )
+        public
     {
-        tokenSymbol      = _symbol;
-        tokenName        = _name;
-        tokenDecimals    = _decimals;
+        tokenSymbol = _symbol;
+        tokenName = _name;
+        tokenDecimals = _decimals;
         totalTokenSupply = 0;
     }
 

--- a/contracts/EIP20Token.sol
+++ b/contracts/EIP20Token.sol
@@ -31,7 +31,7 @@ contract EIP20Token is EIP20Interface {
     /* Storage */
 
     string internal tokenName;
-    string private tokenSymbol;
+    string internal tokenSymbol;
     uint8  private tokenDecimals;
     uint256 internal totalTokenSupply;
 

--- a/contracts/EIP20Token.sol
+++ b/contracts/EIP20Token.sol
@@ -30,7 +30,7 @@ contract EIP20Token is EIP20Interface {
 
     /* Storage */
 
-    string private tokenName;
+    string internal tokenName;
     string private tokenSymbol;
     uint8  private tokenDecimals;
     uint256 internal totalTokenSupply;

--- a/contracts/test/branded_token/OrganizationMockFail.sol
+++ b/contracts/test/branded_token/OrganizationMockFail.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.5.0;
+
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/**
+ *  @title Mock Organization Fail.
+ *
+ *  @notice Mocks Organization functions as failing.
+ */
+contract OrganizationMockFail {
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks failing isOrganization.
+     *
+     * @return bool False.
+     */
+    function isOrganization(address)
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+
+    /**
+     * @notice Mocks failing isWorker.
+     *
+     * @return bool False.
+     */
+    function isWorker(address)
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+}

--- a/test/branded_token/set_name.js
+++ b/test/branded_token/set_name.js
@@ -1,0 +1,113 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const { AccountProvider } = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder.js');
+
+const utils = require('../test_lib/utils');
+const brandedTokenUtils = require('./utils');
+
+contract('BrandedToken::setName', async () => {
+    const newName = 'New BrandedToken';
+
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if msg.sender is not a worker', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+                false,
+            );
+
+            const nonWorker = accountProvider.get();
+
+            await utils.expectRevert(
+                brandedToken.setName(
+                    newName,
+                    { from: nonWorker },
+                ),
+                'Should revert as msg.sender is not a worker.',
+                'Only whitelisted workers are allowed to call this method.',
+            );
+        });
+    });
+
+    contract('Event', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Emits NameSet event', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+            );
+
+            const worker = accountProvider.get();
+
+            const transactionResponse = await brandedToken.setName(
+                newName,
+                { from: worker },
+            );
+
+            const events = Event.decodeTransactionResponse(
+                transactionResponse,
+            );
+
+            assert.strictEqual(
+                events.length,
+                1,
+            );
+
+            Event.assertEqual(events[0], {
+                name: 'NameSet',
+                args: {
+                    _name: newName,
+                },
+            });
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully sets name', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+            );
+
+            const worker = accountProvider.get();
+
+            assert.isOk(
+                await brandedToken.setName.call(
+                    newName,
+                    { from: worker },
+                ),
+            );
+
+            await brandedToken.setName(
+                newName,
+                { from: worker },
+            );
+
+            assert.strictEqual(
+                newName,
+                await brandedToken.name(),
+            );
+        });
+    });
+});

--- a/test/branded_token/set_symbol.js
+++ b/test/branded_token/set_symbol.js
@@ -1,0 +1,113 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const { AccountProvider } = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder.js');
+
+const utils = require('../test_lib/utils');
+const brandedTokenUtils = require('./utils');
+
+contract('BrandedToken::setSymbol', async () => {
+    const newSymbol = 'NBT';
+
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if msg.sender is not a worker', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+                false,
+            );
+
+            const nonWorker = accountProvider.get();
+
+            await utils.expectRevert(
+                brandedToken.setSymbol(
+                    newSymbol,
+                    { from: nonWorker },
+                ),
+                'Should revert as msg.sender is not a worker.',
+                'Only whitelisted workers are allowed to call this method.',
+            );
+        });
+    });
+
+    contract('Event', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Emits SymbolSet event', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+            );
+
+            const worker = accountProvider.get();
+
+            const transactionResponse = await brandedToken.setSymbol(
+                newSymbol,
+                { from: worker },
+            );
+
+            const events = Event.decodeTransactionResponse(
+                transactionResponse,
+            );
+
+            assert.strictEqual(
+                events.length,
+                1,
+            );
+
+            Event.assertEqual(events[0], {
+                name: 'SymbolSet',
+                args: {
+                    _symbol: newSymbol,
+                },
+            });
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully sets symbol', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+            );
+
+            const worker = accountProvider.get();
+
+            assert.isOk(
+                await brandedToken.setSymbol.call(
+                    newSymbol,
+                    { from: worker },
+                ),
+            );
+
+            await brandedToken.setSymbol(
+                newSymbol,
+                { from: worker },
+            );
+
+            assert.strictEqual(
+                newSymbol,
+                await brandedToken.symbol(),
+            );
+        });
+    });
+});

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -17,18 +17,21 @@ const web3 = require('../test_lib/web3.js');
 const BrandedToken = artifacts.require('BrandedToken');
 const EIP20TokenMockPass = artifacts.require('EIP20TokenMockPass');
 const OrganizationMockPass = artifacts.require('OrganizationMockPass');
+const OrganizationMockFail = artifacts.require('OrganizationMockFail');
 
 /**
  * Sets up a BrandedToken.
  */
-module.exports.setupBrandedToken = async () => {
+module.exports.setupBrandedToken = async (accountProvider, useOrganizationMockPass = true) => {
     const valueToken = await EIP20TokenMockPass.new();
-    const symbol = 'BrandedToken';
-    const name = 'BT';
+    const symbol = 'BT';
+    const name = 'BrandedToken';
     const decimals = 18;
     const conversionRate = 35;
     const conversionRateDecimals = 1;
-    const organization = await OrganizationMockPass.new();
+    const organization = await (
+        useOrganizationMockPass ? OrganizationMockPass.new() : OrganizationMockFail.new()
+    );
 
     const brandedToken = await BrandedToken.new(
         valueToken.address,


### PR DESCRIPTION
This PR:
- adds setName to BT (resolves #70)
- adds setSymbol to BT (resolves #71)
- makes linter corrections to `EIP20Token` (as it was already touched in completing the items above)

While it is preferable to have one PR per issue, both of these functions rely on a utility function for testing that this PR adds; consequently, separate PRs would mean unnecessary logistical difficulties for merger.

🕵️‍♀️: the name and symbol state vars' visibilities for EIP20Token are changed from `private` to `internal`; this seemed the simplest way to enable setters and is presumed to be OK since, IIRC, the reason for `private` was specifically to prevent the functionality we now explicitly want to enable (derived contracts writing these vars). **Nevertheless, it seems something to which particular attention is worth drawing.**