### PR TITLE
Contracts: calculate stakeRequestHash per EIP 712

### DIFF
--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -96,6 +96,24 @@ contract BrandedToken is Organized, EIP20Token {
     /** Flag indicating whether restrictions have been lifted for all actors. */
     bool public allRestrictionsLifted;
 
+    /** Domain separator encoding per EIP 712. */
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(address verifyingContract)"
+    );
+
+    /** StakeRequest struct type encoding per EIP 712. */
+    bytes32 public constant BT_STAKE_REQUEST_TYPEHASH = keccak256(
+        "StakeRequest(address staker,uint256 stake,uint256 nonce)"
+    );
+
+    /** Domain separator per EIP 712. */
+    bytes32 public DOMAIN_SEPARATOR = keccak256(
+        abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            this
+        )
+    );
+
     /** Maps staker to stakeRequestHashes. */
     mapping(address => bytes32) public stakeRequestHashes;
 

--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -226,22 +226,15 @@ contract BrandedToken is Organized, EIP20Token {
             "Staker has a stake request hash."
         );
 
-        // TODO: update to calculate stakeRequestHash_ per EIP 712
-        stakeRequestHash_ = keccak256(
-            abi.encodePacked(
-                "stakeRequestHash_",
-                nonce
-            )
-        );
-        stakeRequestHashes[msg.sender] = stakeRequestHash_;
-
-        stakeRequests[stakeRequestHash_] = StakeRequest({
+        StakeRequest memory stakeRequest = StakeRequest({
             staker: msg.sender,
             stake: _stake,
             nonce: nonce
         });
-
-        StakeRequest memory stakeRequest = stakeRequests[stakeRequestHash_];
+        // Calculates hash per EIP 712
+        stakeRequestHash_ = hash(stakeRequest);
+        stakeRequestHashes[msg.sender] = stakeRequestHash_;
+        stakeRequests[stakeRequestHash_] = stakeRequest;
 
         nonce += 1;
 
@@ -639,6 +632,33 @@ contract BrandedToken is Organized, EIP20Token {
             _brandedTokens
             .mul(10 ** uint256(conversionRateDecimals))
             .div(conversionRate)
+        );
+    }
+
+
+    /* Internal Functions */
+
+    /**
+     * @notice Calculates stakeRequestHash according to EIP 712.
+     *
+     * @param _stakeRequest StakeRequest instance to hash.
+     *
+     * @return bytes32 EIP 712 hash of _stakeRequest.
+     */
+    function hash(
+        StakeRequest memory _stakeRequest
+    )
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                BT_STAKE_REQUEST_TYPEHASH,
+                _stakeRequest.staker,
+                _stakeRequest.stake,
+                _stakeRequest.nonce
+            )
         );
     }
 }

--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -97,17 +97,17 @@ contract BrandedToken is Organized, EIP20Token {
     bool public allRestrictionsLifted;
 
     /** Domain separator encoding per EIP 712. */
-    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH = keccak256(
         "EIP712Domain(address verifyingContract)"
     );
 
     /** StakeRequest struct type encoding per EIP 712. */
-    bytes32 public constant BT_STAKE_REQUEST_TYPEHASH = keccak256(
+    bytes32 private constant BT_STAKE_REQUEST_TYPEHASH = keccak256(
         "StakeRequest(address staker,uint256 stake,uint256 nonce)"
     );
 
     /** Domain separator per EIP 712. */
-    bytes32 public DOMAIN_SEPARATOR = keccak256(
+    bytes32 private DOMAIN_SEPARATOR = keccak256(
         abi.encode(
             EIP712_DOMAIN_TYPEHASH,
             this

--- a/contracts/test/branded_token/OrganizationMockWorker.sol
+++ b/contracts/test/branded_token/OrganizationMockWorker.sol
@@ -17,37 +17,42 @@ pragma solidity ^0.5.0;
 
 
 /**
- *  @title Organization Mock Pass.
+ *  @title Organization Mock Worker.
  *
- *  @notice Mocks Organization functions as passing.
+ *  @notice Mocks Organization setWorker and isWorker functions.
  */
-contract OrganizationMockPass {
+contract OrganizationMockWorker {
+
+    address public worker;
 
     /* External Functions */
 
     /**
-     * @notice Mocks passing isOrganization.
+     * @notice Mocks setWorker.
      *
-     * @return bool True.
+     * @param _worker The value to which worker is set.
      */
-    function isOrganization(address)
+    function setWorker(
+        address _worker,
+        uint256
+    )
         external
-        pure
-        returns (bool)
     {
-        return true;
+        worker = _worker;
     }
 
     /**
-     * @notice Mocks passing isWorker.
+     * @notice Mocks isWorker.
      *
-     * @return bool True.
+     * @return bool True if worker == _worker, false if not.
      */
-    function isWorker(address)
+    function isWorker(
+        address _worker
+    )
         external
-        pure
+        view
         returns (bool)
     {
-        return true;
+        return worker == _worker;
     }
 }

--- a/test/branded_token/accept_stake_request.js
+++ b/test/branded_token/accept_stake_request.js
@@ -168,7 +168,15 @@ contract('BrandedToken::acceptStakeRequest', async () => {
                 { from: staker },
             );
 
-            const DOMAIN_SEPARATOR = await brandedToken.DOMAIN_SEPARATOR();
+            const EIP712_DOMAIN_TYPEHASH = web3.utils.soliditySha3(
+                'EIP712Domain(address verifyingContract)',
+            );
+            const DOMAIN_SEPARATOR = web3.utils.soliditySha3(
+                web3.eth.abi.encodeParameters(
+                    ['bytes32', 'address'],
+                    [EIP712_DOMAIN_TYPEHASH, brandedToken.address],
+                ),
+            );
             const stakeRequestHash = await brandedToken.stakeRequestHashes(staker);
 
             // Prepare and sign typed data, for example see:

--- a/test/branded_token/constructor.js
+++ b/test/branded_token/constructor.js
@@ -15,9 +15,7 @@
 const BN = require('bn.js');
 const { AccountProvider } = require('../test_lib/utils.js');
 
-const web3 = require('../test_lib/web3.js');
 const utils = require('../test_lib/utils');
-const brandedTokenUtils = require('./utils');
 
 const BrandedToken = artifacts.require('BrandedToken');
 
@@ -110,42 +108,6 @@ contract('BrandedToken::constructor', async () => {
                     new BN(conversionRateDecimals),
                 ),
                 0,
-            );
-        });
-
-        it('Calculates EIP 712 type hashes and separator per specification', async () => {
-            const {
-                brandedToken,
-            } = await brandedTokenUtils.setupBrandedToken(
-                accountProvider,
-            );
-
-            const EIP712_DOMAIN_TYPEHASH = web3.utils.soliditySha3(
-                'EIP712Domain(address verifyingContract)',
-            );
-            const BT_STAKE_REQUEST_TYPEHASH = web3.utils.soliditySha3(
-                'StakeRequest(address staker,uint256 stake,uint256 nonce)',
-            );
-            const DOMAIN_SEPARATOR = web3.utils.soliditySha3(
-                web3.eth.abi.encodeParameters(
-                    ['bytes32', 'address'],
-                    [EIP712_DOMAIN_TYPEHASH, brandedToken.address],
-                ),
-            );
-
-            assert.strictEqual(
-                EIP712_DOMAIN_TYPEHASH,
-                await brandedToken.EIP712_DOMAIN_TYPEHASH(),
-            );
-
-            assert.strictEqual(
-                DOMAIN_SEPARATOR,
-                await brandedToken.DOMAIN_SEPARATOR(),
-            );
-
-            assert.strictEqual(
-                BT_STAKE_REQUEST_TYPEHASH,
-                await brandedToken.BT_STAKE_REQUEST_TYPEHASH(),
             );
         });
     });

--- a/test/branded_token/constructor.js
+++ b/test/branded_token/constructor.js
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 const BN = require('bn.js');
-const utils = require('../test_lib/utils.js');
 const { AccountProvider } = require('../test_lib/utils.js');
+
+const web3 = require('../test_lib/web3.js');
+const utils = require('../test_lib/utils');
+const brandedTokenUtils = require('./utils');
 
 const BrandedToken = artifacts.require('BrandedToken');
 
@@ -108,6 +110,42 @@ contract('BrandedToken::constructor', async () => {
                     new BN(conversionRateDecimals),
                 ),
                 0,
+            );
+        });
+
+        it('Calculates EIP 712 type hashes and separator per specification', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+            );
+
+            const EIP712_DOMAIN_TYPEHASH = web3.utils.soliditySha3(
+                'EIP712Domain(address verifyingContract)',
+            );
+            const BT_STAKE_REQUEST_TYPEHASH = web3.utils.soliditySha3(
+                'StakeRequest(address staker,uint256 stake,uint256 nonce)',
+            );
+            const DOMAIN_SEPARATOR = web3.utils.soliditySha3(
+                web3.eth.abi.encodeParameters(
+                    ['bytes32', 'address'],
+                    [EIP712_DOMAIN_TYPEHASH, brandedToken.address],
+                ),
+            );
+
+            assert.strictEqual(
+                EIP712_DOMAIN_TYPEHASH,
+                await brandedToken.EIP712_DOMAIN_TYPEHASH(),
+            );
+
+            assert.strictEqual(
+                DOMAIN_SEPARATOR,
+                await brandedToken.DOMAIN_SEPARATOR(),
+            );
+
+            assert.strictEqual(
+                BT_STAKE_REQUEST_TYPEHASH,
+                await brandedToken.BT_STAKE_REQUEST_TYPEHASH(),
             );
         });
     });

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -94,7 +94,7 @@ module.exports.setupBrandedTokenAndAcceptedStakeRequest = async (accountProvider
     );
 
     const r = web3.utils.soliditySha3('r');
-    const s = web3.utils.soliditySha3('r');
+    const s = web3.utils.soliditySha3('s');
     const v = 0;
     const worker = accountProvider.get();
 


### PR DESCRIPTION
This PR makes changes in order to calculate the `stakeRequestHash` consistent with [EIP 712 ](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md):
- declares domain separator and typehash constants ([OIP-1](https://github.com/OpenSTFoundation/OIPs/blob/d639dd49ee897880cdead0900c54c9f5fab1cab7/OIPS/oip-0001.md))
- sets domain separator and typehash constants upon construction
- adds `hash` function for calculating a stakeRequestHash and uses it in `requestStake`
- adds `verifySigner` function to (a) recover public address of stakeRequestHash signer and (b) confirm whether address is a worker; uses verifySigner in `acceptStakeRequest`

Resolves #90.

N.B.: EIP 712 constants are all `private`; while their calculations are not tested in `constructor` tests, their correction calculation is confirmed via additional/updated testing for requestStake and acceptStake. However, the changes from `public` to `private` are all within [a102069](https://github.com/OpenSTFoundation/brandedtoken-contracts/commit/a102069d86a1c6c9dbd6ee8c2350a02f1971869b), should `public` visibility be preferred.