### PR TITLE
Contracts: limit BT conversionRateDecimals to 5.

### DIFF
--- a/contracts/BrandedToken.sol
+++ b/contracts/BrandedToken.sol
@@ -128,6 +128,7 @@ contract BrandedToken is Organized, EIP20Token {
      *      Constructor requires:
      *          - valueToken address is not zero
      *          - conversionRate is not zero
+     *          - conversionRateDecimals is not greater than 5
      *
      * @param _valueToken The value to which valueToken is set.
      * @param _symbol The value to which tokenSymbol, defined in EIP20Token,
@@ -162,6 +163,10 @@ contract BrandedToken is Organized, EIP20Token {
         require(
             _conversionRate != 0,
             "ConversionRate is zero."
+        );
+        require(
+            _conversionRateDecimals <= 5,
+            "ConversionRateDecimals is greater than 5."
         );
 
         valueToken = _valueToken;

--- a/test/branded_token/constructor.js
+++ b/test/branded_token/constructor.js
@@ -26,12 +26,12 @@ contract('BrandedToken::constructor', async () => {
         const symbol = 'BT';
         const name = 'BrandedToken';
         const decimals = 18;
-        const conversionRateDecimals = 1;
         const organization = accountProvider.get();
 
         it('Reverts if valueToken is zero', async () => {
             const valueToken = utils.NULL_ADDRESS;
             const conversionRate = 35;
+            const conversionRateDecimals = 1;
 
             await utils.expectRevert(
                 BrandedToken.new(
@@ -51,6 +51,7 @@ contract('BrandedToken::constructor', async () => {
         it('Reverts if conversionRate is zero', async () => {
             const valueToken = accountProvider.get();
             const conversionRate = 0;
+            const conversionRateDecimals = 1;
 
             await utils.expectRevert(
                 BrandedToken.new(
@@ -64,6 +65,26 @@ contract('BrandedToken::constructor', async () => {
                 ),
                 'Should revert as conversionRate is zero.',
                 'ConversionRate is zero.',
+            );
+        });
+
+        it('Reverts if conversionRateDecimals is greater than 5', async () => {
+            const valueToken = accountProvider.get();
+            const conversionRate = 35;
+            const conversionRateDecimals = 6;
+
+            await utils.expectRevert(
+                BrandedToken.new(
+                    valueToken,
+                    symbol,
+                    name,
+                    decimals,
+                    conversionRate,
+                    conversionRateDecimals,
+                    organization,
+                ),
+                'Should revert as conversionRateDecimals is greater than 5.',
+                'ConversionRateDecimals is greater than 5.',
             );
         });
     });


### PR DESCRIPTION
This PR requires max 5 for `conversionRateDecimals` in `constructor` (resolves #101).