### PR TITLE
Complete testing of various functions

### DIFF
--- a/contracts/test/branded_token/EIP20TokenMockFail.sol
+++ b/contracts/test/branded_token/EIP20TokenMockFail.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.5.0;
+
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/**
+ *  @title Mock EIP20 Token Fail.
+ *
+ *  @notice Mocks EIP20 token functions as failing.
+ */
+contract EIP20TokenMockFail {
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks failing transferFrom.
+     *
+     * @return bool False.
+     */
+    function transferFrom(
+        address,
+        address,
+        uint256
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+}

--- a/contracts/test/branded_token/EIP20TokenMockPassFail.sol
+++ b/contracts/test/branded_token/EIP20TokenMockPassFail.sol
@@ -17,18 +17,24 @@ pragma solidity ^0.5.0;
 
 
 /**
- *  @title Mock EIP20 Token Fail.
+ *  @title Mock EIP20 Token Pass Fail.
  *
- *  @notice Mocks EIP20 token functions as failing.
+ *  @notice Mocks EIP20 token transferFrom as passing and transfer as failing.
+ *          Passing transferFrom but failing transfer enables testing
+ *          functions that invoke transfer but can only be successfully
+ *          called after successfully invoking transferFrom.
  */
-contract EIP20TokenMockFail {
+contract EIP20TokenMockPassFail {
 
     /* External Functions */
 
     /**
-     * @notice Mocks failing transferFrom.
+     * @notice Mocks passing transferFrom.
      *
-     * @return bool False.
+     * @dev Passing transferFrom enable 
+     *      the signature of a worker, as defined in Organization.
+     *
+     * @return bool True.
      */
     function transferFrom(
         address,
@@ -39,7 +45,7 @@ contract EIP20TokenMockFail {
         pure
         returns (bool)
     {
-        return false;
+        return true;
     }
 
     /**

--- a/test/branded_token/lift_restriction.js
+++ b/test/branded_token/lift_restriction.js
@@ -13,10 +13,35 @@
 // limitations under the License.
 
 const { AccountProvider } = require('../test_lib/utils.js');
+
+const utils = require('../test_lib/utils');
 const brandedTokenUtils = require('./utils');
 
 contract('BrandedToken::liftRestriction', async () => {
-    // TODO: add negative tests
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if msg.sender is not a worker', async () => {
+            const {
+                brandedToken,
+            } = await brandedTokenUtils.setupBrandedToken(
+                accountProvider,
+                false,
+            );
+
+            const restrictionLifted = [accountProvider.get()];
+            const nonWorker = accountProvider.get();
+
+            await utils.expectRevert(
+                brandedToken.liftRestriction(
+                    restrictionLifted,
+                    { from: nonWorker },
+                ),
+                'Should revert as msg.sender is not a worker.',
+                'Only whitelisted workers are allowed to call this method.',
+            );
+        });
+    });
 
     contract('Storage', async (accounts) => {
         const accountProvider = new AccountProvider(accounts);

--- a/test/branded_token/redeem.js
+++ b/test/branded_token/redeem.js
@@ -29,7 +29,7 @@ contract('BrandedToken::redeem', async () => {
             } = await brandedTokenUtils.setupBrandedToken(
                 accountProvider,
                 true,
-                false,
+                false, // Use EIP20TokenMockPassFail
             );
 
             await utils.expectRevert(

--- a/test/branded_token/revoke_stake_request.js
+++ b/test/branded_token/revoke_stake_request.js
@@ -42,6 +42,27 @@ contract('BrandedToken::revokeStakeRequest', async () => {
                 'Msg.sender is not staker.',
             );
         });
+
+        it('Reverts if valueToken.transfer returns false', async () => {
+            const {
+                brandedToken,
+                staker,
+                stakeRequestHash,
+            } = await brandedTokenUtils.setupBrandedTokenAndStakeRequest(
+                accountProvider,
+                true,
+                false,
+            );
+
+            await utils.expectRevert(
+                brandedToken.revokeStakeRequest(
+                    stakeRequestHash,
+                    { from: staker },
+                ),
+                'Should revert as valueToken.transfer returned false.',
+                'ValueToken.transfer returned false.',
+            );
+        });
     });
 
     contract('Event', async (accounts) => {

--- a/test/branded_token/revoke_stake_request.js
+++ b/test/branded_token/revoke_stake_request.js
@@ -103,5 +103,55 @@ contract('BrandedToken::revokeStakeRequest', async () => {
         });
     });
 
-    // TODO: add storage tests
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully revokes stake request', async () => {
+            const {
+                brandedToken,
+                staker,
+                stakeRequestHash,
+            } = await brandedTokenUtils.setupBrandedTokenAndStakeRequest(
+                accountProvider,
+            );
+
+            assert.isOk(
+                await brandedToken.revokeStakeRequest.call(
+                    stakeRequestHash,
+                    { from: staker },
+                ),
+            );
+
+            await brandedToken.revokeStakeRequest(
+                stakeRequestHash,
+                { from: staker },
+            );
+
+            assert.strictEqual(
+                await brandedToken.stakeRequestHashes(staker),
+                utils.NULL_BYTES32,
+            );
+
+            const stakeRequest = await brandedToken.stakeRequests(stakeRequestHash);
+
+            assert.strictEqual(
+                stakeRequest.staker,
+                utils.NULL_ADDRESS,
+            );
+
+            assert.strictEqual(
+                stakeRequest.stake.cmp(
+                    new BN(0),
+                ),
+                0,
+            );
+
+            assert.strictEqual(
+                stakeRequest.nonce.cmp(
+                    new BN(0),
+                ),
+                0,
+            );
+        });
+    });
 });

--- a/test/branded_token/revoke_stake_request.js
+++ b/test/branded_token/revoke_stake_request.js
@@ -51,7 +51,7 @@ contract('BrandedToken::revokeStakeRequest', async () => {
             } = await brandedTokenUtils.setupBrandedTokenAndStakeRequest(
                 accountProvider,
                 true,
-                false,
+                false, // Use EIP20TokenMockPassFail
             );
 
             await utils.expectRevert(

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -58,10 +58,18 @@ module.exports.setupBrandedToken = async (
 /**
  * Sets up a BrandedToken and a stake request.
  */
-module.exports.setupBrandedTokenAndStakeRequest = async (accountProvider) => {
+module.exports.setupBrandedTokenAndStakeRequest = async (
+    accountProvider,
+    useOrganizationMockPass = true,
+    useEIP20TokenMockPass = true,
+) => {
     const {
         brandedToken,
-    } = await this.setupBrandedToken();
+    } = await this.setupBrandedToken(
+        accountProvider,
+        useOrganizationMockPass,
+        useEIP20TokenMockPass,
+    );
 
     const staker = accountProvider.get();
     const stake = 2;

--- a/test/branded_token/utils.js
+++ b/test/branded_token/utils.js
@@ -16,7 +16,7 @@ const web3 = require('../test_lib/web3.js');
 
 const BrandedToken = artifacts.require('BrandedToken');
 const EIP20TokenMockPass = artifacts.require('EIP20TokenMockPass');
-const EIP20TokenMockFail = artifacts.require('EIP20TokenMockFail');
+const EIP20TokenMockPassFail = artifacts.require('EIP20TokenMockPassFail');
 const OrganizationMockPass = artifacts.require('OrganizationMockPass');
 const OrganizationMockFail = artifacts.require('OrganizationMockFail');
 
@@ -29,7 +29,7 @@ module.exports.setupBrandedToken = async (
     useEIP20TokenMockPass = true,
 ) => {
     const valueToken = await (
-        useEIP20TokenMockPass ? EIP20TokenMockPass.new() : EIP20TokenMockFail.new()
+        useEIP20TokenMockPass ? EIP20TokenMockPass.new() : EIP20TokenMockPassFail.new()
     );
     const symbol = 'BT';
     const name = 'BrandedToken';


### PR DESCRIPTION
This PR completes testing (negative and storage) for:
- BT.revokeStakeRequest (resolves #96)
- BT.acceptStakeRequest (resolves #91)
- BT.rejectStakeRequest (resolves #109)
- BT.liftRestriction (resolves #113)
- BT.requestStake (resolves #95)

While it is preferable to complete only a single ticket per PR, the similarities between these tests (and their shared usage new/changed utilities) support doing them in a relatively small combined PR.