### PR TITLE
Added await before calling expectRevert to resolve promises

### DIFF
--- a/test/gateway_composer/accept_stake_request.js
+++ b/test/gateway_composer/accept_stake_request.js
@@ -40,7 +40,7 @@ contract('GatewayComposer::acceptStakeRequest', async (accounts) => {
             const hashLock = web3.utils.soliditySha3('hl');
 
             const invalidStakeRequestHash = web3.utils.soliditySha3('invalid');
-            utils.expectRevert(gatewayComposer.acceptStakeRequest(
+            await utils.expectRevert(gatewayComposer.acceptStakeRequest(
                 invalidStakeRequestHash,
                 r,
                 s,
@@ -110,7 +110,7 @@ contract('GatewayComposer::acceptStakeRequest', async (accounts) => {
             const v = 0;
             const hashLock = web3.utils.soliditySha3('hl');
 
-            utils.expectRevert(gatewayComposer.acceptStakeRequest(
+            await utils.expectRevert(gatewayComposer.acceptStakeRequest(
                 stakeRequestHash,
                 r,
                 s,
@@ -177,7 +177,7 @@ contract('GatewayComposer::acceptStakeRequest', async (accounts) => {
             const v = 0;
             const hashLock = web3.utils.soliditySha3('hl');
 
-            utils.expectRevert(gatewayComposer.acceptStakeRequest(
+            await utils.expectRevert(gatewayComposer.acceptStakeRequest(
                 stakeRequestHash,
                 r,
                 s,

--- a/test/gateway_composer/approve_token.js
+++ b/test/gateway_composer/approve_token.js
@@ -30,7 +30,7 @@ contract('GatewayComposer::approveToken', async (accounts) => {
 
             const spender = accountProvider.get();
             const amount = new BN(10);
-            utils.expectRevert(gatewayComposer.approveToken(
+            await utils.expectRevert(gatewayComposer.approveToken(
                 valueToken.address,
                 spender,
                 amount,
@@ -48,7 +48,7 @@ contract('GatewayComposer::approveToken', async (accounts) => {
 
             const to = accountProvider.get();
             const amount = new BN(10);
-            utils.expectRevert(gatewayComposer.approveToken(
+            await utils.expectRevert(gatewayComposer.approveToken(
                 utils.NULL_ADDRESS,
                 to,
                 amount,

--- a/test/gateway_composer/constructor.js
+++ b/test/gateway_composer/constructor.js
@@ -37,7 +37,7 @@ contract('GatewayComposer::constructor', async (accounts) => {
         });
 
         it('Reverts if owner address is zero.', async () => {
-            utils.expectRevert(GatewayComposer.new(
+            await utils.expectRevert(GatewayComposer.new(
                 utils.NULL_ADDRESS,
                 valueToken,
                 brandedToken,
@@ -48,7 +48,7 @@ contract('GatewayComposer::constructor', async (accounts) => {
         });
 
         it('Reverts if ValueToken address is zero.', async () => {
-            utils.expectRevert(GatewayComposer.new(
+            await utils.expectRevert(GatewayComposer.new(
                 owner,
                 utils.NULL_ADDRESS,
                 brandedToken,
@@ -59,7 +59,7 @@ contract('GatewayComposer::constructor', async (accounts) => {
         });
 
         it('Reverts if branded token address is zero.', async () => {
-            utils.expectRevert(GatewayComposer.new(
+            await utils.expectRevert(GatewayComposer.new(
                 owner,
                 valueToken,
                 utils.NULL_ADDRESS,
@@ -80,7 +80,7 @@ contract('GatewayComposer::constructor', async (accounts) => {
                 accountProvider.get(),
                 { from: deployer },
             );
-            utils.expectRevert(GatewayComposer.new(
+            await utils.expectRevert(GatewayComposer.new(
                 owner,
                 valueToken,
                 brandedToken.address,

--- a/test/gateway_composer/destroy.js
+++ b/test/gateway_composer/destroy.js
@@ -31,7 +31,7 @@ contract('GatewayComposer::destroy', async (accounts) => {
                 owner,
             } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
             await valueToken.setBalance(gatewayComposer.address, new BN(10));
-            utils.expectRevert(
+            await utils.expectRevert(
                 gatewayComposer.destroy({ from: owner }),
                 'It should revert as ValueToken balance is not 0.',
                 'ValueToken balance should be 0.',
@@ -44,7 +44,7 @@ contract('GatewayComposer::destroy', async (accounts) => {
                 gatewayComposer,
             } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
             await valueToken.setBalance(gatewayComposer.address, new BN(10));
-            utils.expectRevert(
+            await utils.expectRevert(
                 gatewayComposer.destroy({ from: accountProvider.get() }),
                 'It should revert as only owner can call the function.',
                 'Only owner can call the function.',
@@ -83,7 +83,7 @@ contract('GatewayComposer::destroy', async (accounts) => {
                 nonce,
                 { from: owner },
             );
-            utils.expectRevert(
+            await utils.expectRevert(
                 gatewayComposer.destroy({ from: owner }),
                 'It should revert as there are ongoing stake requests.',
                 'In progress stake requests are present.',

--- a/test/gateway_composer/request_stake.js
+++ b/test/gateway_composer/request_stake.js
@@ -55,7 +55,7 @@ contract('GatewayComposer::requestStake', async (accounts) => {
             const mintAmount = await brandedToken.convertToBrandedTokens(stakeAmount);
 
 
-            utils.expectRevert(gatewayComposer.requestStake(
+            await utils.expectRevert(gatewayComposer.requestStake(
                 0,
                 mintAmount,
                 gateway,
@@ -86,7 +86,7 @@ contract('GatewayComposer::requestStake', async (accounts) => {
             );
 
             const mintAmount = await brandedToken.convertToBrandedTokens(stakeAmount);
-            utils.expectRevert(gatewayComposer.requestStake(
+            await utils.expectRevert(gatewayComposer.requestStake(
                 0,
                 mintAmount,
                 gateway,
@@ -116,7 +116,7 @@ contract('GatewayComposer::requestStake', async (accounts) => {
             );
 
             const invalidMintAmount = 0;
-            utils.expectRevert(gatewayComposer.requestStake(
+            await utils.expectRevert(gatewayComposer.requestStake(
                 stakeAmount,
                 invalidMintAmount,
                 gateway,
@@ -148,7 +148,7 @@ contract('GatewayComposer::requestStake', async (accounts) => {
             );
 
             const mintAmount = await brandedToken.convertToBrandedTokens(stakeAmount);
-            utils.expectRevert(gatewayComposer.requestStake(
+            await utils.expectRevert(gatewayComposer.requestStake(
                 stakeAmount,
                 mintAmount,
                 utils.NULL_ADDRESS,
@@ -179,7 +179,7 @@ contract('GatewayComposer::requestStake', async (accounts) => {
             );
 
             const mintAmount = await brandedToken.convertToBrandedTokens(stakeAmount);
-            utils.expectRevert(gatewayComposer.requestStake(
+            await utils.expectRevert(gatewayComposer.requestStake(
                 stakeAmount,
                 mintAmount,
                 gateway,
@@ -202,7 +202,7 @@ contract('GatewayComposer::requestStake', async (accounts) => {
 
             const stakeAmount = 1;
             const mintAmount = await brandedToken.convertToBrandedTokens(stakeAmount);
-            utils.expectRevert(gatewayComposer.requestStake(
+            await utils.expectRevert(gatewayComposer.requestStake(
                 stakeAmount,
                 mintAmount,
                 gateway,

--- a/test/gateway_composer/revoke_stake_request.js
+++ b/test/gateway_composer/revoke_stake_request.js
@@ -29,7 +29,7 @@ contract('GatewayComposer::revokeStakeRequest', async (accounts) => {
             } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
 
             const stakeRequestHash = web3.utils.soliditySha3('hash');
-            utils.expectRevert(gatewayComposer.revokeStakeRequest(
+            await utils.expectRevert(gatewayComposer.revokeStakeRequest(
                 stakeRequestHash,
                 { from: accountProvider.get() },
             ),
@@ -44,7 +44,7 @@ contract('GatewayComposer::revokeStakeRequest', async (accounts) => {
             } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
 
             const invalidStakeRequestHash = web3.utils.soliditySha3('invalid');
-            utils.expectRevert(gatewayComposer.revokeStakeRequest(
+            await utils.expectRevert(gatewayComposer.revokeStakeRequest(
                 invalidStakeRequestHash,
                 { from: owner },
             ),
@@ -98,7 +98,7 @@ contract('GatewayComposer::revokeStakeRequest', async (accounts) => {
                 { from: owner },
             );
 
-            utils.expectRevert(gatewayComposer.revokeStakeRequest(
+            await utils.expectRevert(gatewayComposer.revokeStakeRequest(
                 stakeRequestHash,
                 { from: owner },
             ),

--- a/test/gateway_composer/transfer_token.js
+++ b/test/gateway_composer/transfer_token.js
@@ -30,7 +30,7 @@ contract('GatewayComposer::transferToken', async (accounts) => {
 
             const to = accountProvider.get();
             const amount = new BN(10);
-            utils.expectRevert(gatewayComposer.transferToken(
+            await utils.expectRevert(gatewayComposer.transferToken(
                 valueToken.address,
                 to,
                 amount,
@@ -48,7 +48,7 @@ contract('GatewayComposer::transferToken', async (accounts) => {
 
             const to = accountProvider.get();
             const amount = new BN(10);
-            utils.expectRevert(gatewayComposer.transferToken(
+            await utils.expectRevert(gatewayComposer.transferToken(
                 utils.NULL_ADDRESS,
                 to,
                 amount,
@@ -70,7 +70,7 @@ contract('GatewayComposer::transferToken', async (accounts) => {
 
             const to = accountProvider.get();
             const amount = new BN(10);
-            utils.expectRevert(gatewayComposer.transferToken(
+            await utils.expectRevert(gatewayComposer.transferToken(
                 valueToken.address,
                 to,
                 amount,

--- a/test/utility_branded_token/constructor.js
+++ b/test/utility_branded_token/constructor.js
@@ -39,7 +39,7 @@ contract('UtilityBrandedToken::constructor', async (accounts) => {
 
     describe('Negative Tests', async () => {
         it('Reverts if null address is passed as organization', async () => {
-            utils.expectRevert(UtilityBrandedToken.new(
+            await utils.expectRevert(UtilityBrandedToken.new(
                 utils.NULL_ADDRESS,
                 SYMBOL,
                 NAME,


### PR DESCRIPTION
Searched in complete repository if await is missing before calling expectRevert.
This is important to resolve any promise which gets unresolved.

The tests all currently pass, but that because when some tests are commented out, other tests fail, when they should not be affected at all—this is presumably because promises are not resolved.

Fixes ( #117 )