### PR TITLE
Contracts: add GC.revertStake

### DIFF
--- a/contracts/GatewayInterface.sol
+++ b/contracts/GatewayInterface.sol
@@ -62,4 +62,28 @@ interface GatewayInterface {
         external
         returns (bytes32 messageHash_);
 
+    /**
+     * @notice Revert stake process and get the stake
+     *         amount back. Only staker can revert stake by providing
+     *         penalty i.e. 1.5 times of bounty amount. On progress revert stake
+     *         penalty and facilitator bounty will be burned.
+     *
+     * @dev To revert the the sender must sign the sha3(messageHash, nonce+1)
+     *
+     * @param _messageHash Message hash.
+     *
+     * @return staker_ Staker address
+     * @return stakerNonce_ Staker nonce
+     * @return amount_ Stake amount
+     */
+    function revertStake(
+        bytes32 _messageHash
+    )
+        external
+        returns
+    (
+        address staker_,
+        uint256 stakerNonce_,
+        uint256 amount_
+    );
 }

--- a/contracts/test/gateway/MockGatewayPass.sol
+++ b/contracts/test/gateway/MockGatewayPass.sol
@@ -61,11 +61,33 @@ contract MockGatewayPass {
         uint256,
         bytes32
     )
-        pure
         external
+        pure
         returns (bytes32)
     {
         return bytes32(0);
     }
 
+    /**
+     * @notice Revert stake process and get the stake
+     *         amount back. Only staker can revert stake by providing
+     *         penalty i.e. 1.5 times of bounty amount. On progress revert stake
+     *         penalty and facilitator bounty will be burned.
+     *
+     * @dev The only parameter is _messageHash.
+     *
+     *      Returns are in below order:
+     *      - staker_
+     *      - stakerNonce_
+     *      - amount_
+     */
+    function revertStake(
+        bytes32
+    )
+        external
+        pure
+        returns (address, uint256, uint256)
+    {
+        return (address(0), uint256(0), uint256(0));
+    }
 }

--- a/test/gateway_composer/revert_stake.js
+++ b/test/gateway_composer/revert_stake.js
@@ -1,0 +1,128 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const utils = require('../test_lib/utils');
+const { AccountProvider } = require('../test_lib/utils.js');
+const web3 = require('../test_lib/web3.js');
+
+const gatewayComposerUtils = require('./utils');
+
+contract('GatewayComposer::revertStake', async (accounts) => {
+    contract('Negative Tests', async () => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Fails when owner is not the caller', async () => {
+            const {
+                gatewayComposer,
+            } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
+
+            const {
+                gateway,
+            } = await gatewayComposerUtils.setupGatewayPass(
+                accountProvider,
+            );
+
+            const penalty = 0;
+            const messageHash = web3.utils.soliditySha3('hash');
+
+            await utils.expectRevert(
+                gatewayComposer.revertStake(
+                    gateway.address,
+                    penalty,
+                    messageHash,
+                    { from: accountProvider.get() },
+                ),
+                'Should revert as msg.sender is not the owner.',
+                'Only owner can call the function.',
+            );
+        });
+
+        it('Fails when gateway address is zero', async () => {
+            const {
+                gatewayComposer,
+                owner,
+            } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
+
+            const gateway = utils.NULL_ADDRESS;
+            const penalty = 0;
+            const messageHash = web3.utils.soliditySha3('hash');
+
+            await utils.expectRevert(
+                gatewayComposer.revertStake(
+                    gateway,
+                    penalty,
+                    messageHash,
+                    { from: owner },
+                ),
+                'Should revert as gateway address is zero.',
+                'Gateway address is zero.',
+            );
+        });
+
+        it('Fails if valueToken transferFrom returns false', async () => {
+            const {
+                gatewayComposer,
+                owner,
+            } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
+
+            const {
+                gateway,
+            } = await gatewayComposerUtils.setupGatewayPass(
+                accountProvider,
+            );
+
+            const penalty = 1;
+            const messageHash = web3.utils.soliditySha3('hash');
+
+            await utils.expectRevert(
+                gatewayComposer.revertStake(
+                    gateway.address,
+                    penalty,
+                    messageHash,
+                    { from: owner },
+                ),
+                'Should revert as valueToken.transferFrom returned false.',
+            );
+        });
+    });
+
+    contract('Positive Tests', async () => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Returns true on successful execution', async () => {
+            const {
+                gatewayComposer,
+                owner,
+            } = await gatewayComposerUtils.setupGatewayComposer(accountProvider);
+
+            const {
+                gateway,
+            } = await gatewayComposerUtils.setupGatewayPass(
+                accountProvider,
+            );
+
+            const penalty = 0;
+            const messageHash = web3.utils.soliditySha3('hash');
+
+            assert.isOk(
+                await gatewayComposer.revertStake.call(
+                    gateway.address,
+                    penalty,
+                    messageHash,
+                    { from: owner },
+                ),
+            );
+        });
+    });
+});


### PR DESCRIPTION
This PR adds `revertStake`.

🚨 Presently, the code here diverges from the spec in #81. Thus, this PR should not be approved/merged until the acceptability of this solution is confirmed.

✏️ N.B.: this PR does not test:
- `valueToken.approve`—this is to stay consistent with other tests in this area, which use EIP20TokenMock, where `approve` can only fail due to a runtime error
- `Gateway.revertStake`—GC neither cares about nor is necessarily able to validate all returns from an arbitrary Gateway