### PR TITLE
Reentrancy in UBT

### DIFF
--- a/contracts/UtilityBrandedToken.sol
+++ b/contracts/UtilityBrandedToken.sol
@@ -151,13 +151,13 @@ contract UtilityBrandedToken is EIP20Token, UtilityTokenInterface, Internal {
             "CoGateway address should not be zero."
         );
 
+        coGateway = _coGateway;
+
         require(
             CoGatewayUtilityTokenInterface(_coGateway).utilityToken() ==
             address(this),
             "CoGateway.utilityToken is required to be UBT address."
         );
-
-        coGateway = _coGateway;
 
         emit CoGatewaySet(coGateway);
 


### PR DESCRIPTION
Changes done to avoid reentrancy in `setCogateway` method in UtilityBrandedToken